### PR TITLE
Use libfuse3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ apk update
 apk add alpine-sdk util-linux strace file autoconf automake libtool
 
 # Build static squashfuse
-apk add fuse3-dev fuse3-static zstd-dev zstd-static zlib-dev zlib-static # fuse-static fuse-dev
+apk add fuse3-dev fuse3-static zstd-dev zlib-dev zlib-static # fuse-static fuse-dev
 wget -c -q "https://github.com/vasi/squashfuse/archive/e51978c.tar.gz"
 tar xf e51978c.tar.gz
 cd squashfuse-*/

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ apk update
 apk add alpine-sdk util-linux strace file autoconf automake libtool
 
 # Build static squashfuse
-apk add fuse-dev fuse-static zstd-dev zstd-static zlib-dev zlib-static # fuse3-static fuse3-dev
+apk add fuse3-dev fuse3-static zstd-dev zstd-static zlib-dev zlib-static # fuse-static fuse-dev
 wget -c -q "https://github.com/vasi/squashfuse/archive/e51978c.tar.gz"
 tar xf e51978c.tar.gz
 cd squashfuse-*/
@@ -26,12 +26,12 @@ cd -
 # Build static AppImage runtime
 export GIT_COMMIT=$(cat src/runtime/version)
 cd src/runtime
-make runtime-fuse2 -j$(nproc)
-file runtime-fuse2
-strip runtime-fuse2
-ls -lh runtime-fuse2
-echo -ne 'AI\x02' | dd of=runtime-fuse2 bs=1 count=3 seek=8 conv=notrunc # magic bytes, always do AFTER strip
+make runtime-fuse3 -j$(nproc)
+file runtime-fuse3
+strip runtime-fuse3
+ls -lh runtime-fuse3
+echo -ne 'AI\x02' | dd of=runtime-fuse3 bs=1 count=3 seek=8 conv=notrunc # magic bytes, always do AFTER strip
 cd -
 
 mkdir -p out
-cp src/runtime/runtime-fuse2 out/runtime-fuse2-$ARCHITECTURE
+cp src/runtime/runtime-fuse3 out/runtime-fuse3-$ARCHITECTURE

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -44,5 +44,5 @@ sudo umount miniroot/proc miniroot/sys miniroot/dev
 if [ "$ARCHITECTURE" = "x86" ] ; then ARCHITECTURE=i686 ; fi
 
 mkdir out/
-sudo find miniroot/ -type f -executable -name 'runtime-fuse2' -exec cp {} out/runtime-fuse2-$ARCHITECTURE \;
+sudo find miniroot/ -type f -executable -name 'runtime-fuse3' -exec cp {} out/runtime-fuse3-$ARCHITECTURE \;
 sudo rm -rf miniroot/

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -6,7 +6,7 @@ set -ex
 # Download and extract minimal Alpine system
 #############################################
 
-wget http://dl-cdn.alpinelinux.org/alpine/v3.15/releases/$ARCHITECTURE/alpine-minirootfs-3.15.4-$ARCHITECTURE.tar.gz
+wget http://dl-cdn.alpinelinux.org/alpine/v3.17/releases/$ARCHITECTURE/alpine-minirootfs-3.17.2-$ARCHITECTURE.tar.gz
 sudo rm -rf ./miniroot  true # Clean up from previous runs
 mkdir -p ./miniroot
 cd ./miniroot

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -2,14 +2,14 @@ CC            = gcc
 CFLAGS        = -std=gnu99 -s -Os -D_FILE_OFFSET_BITS=64 -DGIT_COMMIT=\"${GIT_COMMIT}\" -T data_sections.ld -ffunction-sections -fdata-sections -Wl,--gc-sections -static
 LIBS          = -lsquashfuse -lsquashfuse_ll -lzstd -lz
 
-all: runtime-fuse2 runtime-fuse3
+all: runtime-fuse3 runtime-fuse3
 
 # Compile runtime
-runtime-fuse2.o: runtime.c
-	$(CC) -I/usr/local/include/squashfuse -I/usr/include/fuse -o runtime-fuse2.o -c $(CFLAGS) $^
+runtime-fuse3.o: runtime.c
+	$(CC) -I/usr/local/include/squashfuse -I/usr/include/fuse -o runtime-fuse3.o -c $(CFLAGS) $^
 
-runtime-fuse2: runtime-fuse2.o
-	$(CC) $(CFLAGS) $^ $(LIBS) -lfuse -o runtime-fuse2
+runtime-fuse3: runtime-fuse3.o
+	$(CC) $(CFLAGS) $^ $(LIBS) -lfuse -o runtime-fuse3
 
 runtime-fuse3.o: runtime.c
 	$(CC) -I/usr/local/include/squashfuse -I/usr/include/fuse3 -o runtime-fuse3.o -c $(CFLAGS) $^
@@ -18,4 +18,4 @@ runtime-fuse3: runtime-fuse3.o
 	$(CC) $(CFLAGS) $^ $(LIBS) -lfuse3 -o runtime-fuse3
 
 clean:
-	rm -f *.o runtime-fuse2 runtime-fuse3
+	rm -f *.o runtime-fuse3 runtime-fuse3


### PR DESCRIPTION
We are not interested in updating the major version of the statically linked libfuse all the time. However, it has been said that upstream does not provide security fixes for libfuse2 anymore (is there a link to this?). Hence, we should use libfuse3 in the hope that the FUSE project will stay with that major version indefinitely.

[libfuse2 CVEs](https://www.cvedetails.com/vulnerability-list.php?vendor_id=3090&product_id=0&version_id=0&page=1&hasexp=0&opdos=0&opec=0&opov=0&opcsrf=0&opgpriv=0&opsqli=0&opxss=0&opdirt=0&opmemc=0&ophttprs=0&opbyp=0&opfileinc=0&opginf=0&cvssscoremin=0&cvssscoremax=0&year=0&month=0&cweid=0&order=1&trc=5&sha=04362d83280f8efe4c0f9668df424235042af263)