### PR TITLE
Remove uraimo/run-on-arch-action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,25 +43,10 @@ jobs:
            git rev-parse --short HEAD  | xargs >> src/runtime/version
 
     - name: Build
-      if: contains(matrix.qemu_arch, 'x86')
       env:
         ARCHITECTURE: ${{ matrix.appimage_arch }}
       run: ./chroot_build.sh
 
-    - name: Build (qemu)
-      if: ${{ !contains(matrix.qemu_arch, 'x86') }}
-      uses: uraimo/run-on-arch-action@v2
-      with:
-        arch: ${{ matrix.qemu_arch }}
-        distro: alpine_edge
-        env: |
-          ARCHITECTURE: ${{ matrix.appimage_arch }}
-        dockerRunArgs: |
-          --volume "${PWD}/out:/out"
-          --volume "${PWD}/src:/src"
-        run: |
-             ./build.sh
-             # echo "artifactName=$GITHUB_RUN_NUMBER_$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v3
       with:
         name: artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: uraimo/run-on-arch-action@v2
       with:
         arch: ${{ matrix.qemu_arch }}
-        distro: alpine_latest
+        distro: alpine_edge
         env: |
           ARCHITECTURE: ${{ matrix.appimage_arch }}
         dockerRunArgs: |

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ apk update
 apk add alpine-sdk util-linux strace file autoconf automake libtool
 
 # Build static squashfuse
-apk add fuse3-dev fuse3-static zstd-dev zstd-static zlib-dev zlib-static # fuse-static fuse-dev
+apk add fuse3-dev fuse3-static zstd-dev zlib-dev zlib-static # fuse-static fuse-dev
 find / -name "libzstd.*" 2>/dev/null || true
 wget -c -q "https://github.com/vasi/squashfuse/archive/e51978c.tar.gz"
 tar xf e51978c.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ apk update
 apk add alpine-sdk util-linux strace file autoconf automake libtool
 
 # Build static squashfuse
-apk add fuse3-dev fuse3-static libzstd zstd-dev zlib-dev zlib-static # fuse-static fuse-dev
+apk add fuse3-dev fuse3-static zstd-dev zstd-static zlib-dev zlib-static # fuse-static fuse-dev
 find / -name "libzstd.*" 2>/dev/null || true
 wget -c -q "https://github.com/vasi/squashfuse/archive/e51978c.tar.gz"
 tar xf e51978c.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -8,10 +8,11 @@ if ! command -v apk; then
 fi
 
 apk update
-apk add alpine-sdk util-linux strace file autoconf automake libtool libzstd
+apk add alpine-sdk util-linux strace file autoconf automake libtool
 
 # Build static squashfuse
-apk add fuse3-dev fuse3-static zstd-dev zlib-dev zlib-static # fuse-static fuse-dev
+apk add fuse3-dev fuse3-static libzstd zstd-dev zlib-dev zlib-static # fuse-static fuse-dev
+find / -name "libzstd.*" 2>/dev/null || true
 wget -c -q "https://github.com/vasi/squashfuse/archive/e51978c.tar.gz"
 tar xf e51978c.tar.gz
 cd squashfuse-*/

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ if ! command -v apk; then
 fi
 
 apk update
-apk add alpine-sdk util-linux strace file autoconf automake libtool
+apk add alpine-sdk util-linux strace file autoconf automake libtool libzstd
 
 # Build static squashfuse
 apk add fuse3-dev fuse3-static zstd-dev zlib-dev zlib-static # fuse-static fuse-dev

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -36,8 +36,8 @@ elif [ "$ARCHITECTURE" = "aarch64" ] ; then
     sudo apt-get -y install qemu-user-static
     sudo cp $(which qemu-aarch64-static) miniroot/usr/bin
     sudo cp build.sh miniroot/build.sh && sudo chroot miniroot qemu-aarch64-static /bin/sh -ex /build.sh
-elif [ "$ARCHITECTURE" = "armv7" ] ; then
-    echo "Architecture is armv7, hence using qemu-arm-static"
+elif [ "$ARCHITECTURE" = "armhf" ] ; then
+    echo "Architecture is armhf, hence using qemu-arm-static"
     sudo apt-get -y install qemu-user-static
     sudo cp $(which qemu-arm-static) miniroot/usr/bin
     sudo cp build.sh miniroot/build.sh && sudo chroot miniroot qemu-arm-static /bin/sh -ex /build.sh

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -24,19 +24,19 @@ sudo mount -t proc none miniroot/proc
 sudo mount -t sysfs none miniroot/sys
 sudo cp -p /etc/resolv.conf miniroot/etc/
 
-sudo apt-get -y install qemu-user-static
-cp $(which qemu-arm-static) miniroot/usr/bin
-
 #############################################
 # Run build.sh in chroot
 #############################################
 
 if [ "$ARCHITECTURE" = "x86" ] || [ "$ARCHITECTURE" = "x86_64" ]; then
     echo "Architecture is x86 or x86_64, hence not using qemu-arm-static"
-    sudo chroot miniroot /bin/sh -ex <build.sh
+    sudo chroot miniroot /bin/sh -ex build.sh
 else
     echo "Architecture is something else, hence using qemu-arm-static"
-    sudo chroot miniroot qemu-arm-static /bin/sh -ex <build.sh
+    sudo apt-get -y install qemu-user-static
+    sudo cp $(which qemu-arm-static) miniroot/usr/bin
+    # sudo chroot miniroot qemu-arm-static /bin/sh -ex <build.sh
+    sudo chroot miniroot qemu-arm-static /bin/sh -ex build.sh
 fi
 
 #############################################

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -31,12 +31,19 @@ sudo cp -p /etc/resolv.conf miniroot/etc/
 if [ "$ARCHITECTURE" = "x86" ] || [ "$ARCHITECTURE" = "x86_64" ]; then
     echo "Architecture is x86 or x86_64, hence not using qemu-arm-static"
     sudo cp build.sh miniroot/build.sh && sudo chroot miniroot /bin/sh -ex /build.sh
-else
-    echo "Architecture is something else, hence using qemu-arm-static"
+elif [ "$ARCHITECTURE" = "aarch64" ] ; then
+    echo "Architecture is aarch64, hence using qemu-aarch64-static"
+    sudo apt-get -y install qemu-user-static
+    sudo cp $(which qemu-aarch64-static) miniroot/usr/bin
+    sudo cp build.sh miniroot/build.sh && sudo chroot miniroot qemu-aarch64-static /bin/sh -ex /build.sh
+elif [ "$ARCHITECTURE" = "armv7" ] ; then
+    echo "Architecture is armv7, hence using qemu-arm-static"
     sudo apt-get -y install qemu-user-static
     sudo cp $(which qemu-arm-static) miniroot/usr/bin
-    # sudo chroot miniroot qemu-arm-static /bin/sh -ex <build.sh
     sudo cp build.sh miniroot/build.sh && sudo chroot miniroot qemu-arm-static /bin/sh -ex /build.sh
+else
+    echo "Edit chroot_build.sh to support this architecture as well, it should be easy"
+    exit 1
 fi
 
 #############################################

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -24,11 +24,20 @@ sudo mount -t proc none miniroot/proc
 sudo mount -t sysfs none miniroot/sys
 sudo cp -p /etc/resolv.conf miniroot/etc/
 
+sudo apt-get -y install qemu-user-static
+cp $(which qemu-arm-static) miniroot/usr/bin
+
 #############################################
 # Run build.sh in chroot
 #############################################
 
-sudo chroot miniroot /bin/sh -ex <build.sh
+if [ "$ARCHITECTURE" = "x86" ] || [ "$ARCHITECTURE" = "x86_64" ]; then
+    echo "Architecture is x86 or x86_64, hence not using qemu-arm-static"
+    sudo chroot miniroot /bin/sh -ex <build.sh
+else
+    echo "Architecture is something else, hence using qemu-arm-static"
+    sudo chroot miniroot qemu-arm-static /bin/sh -ex <build.sh
+fi
 
 #############################################
 # Clean up chroot

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -30,13 +30,13 @@ sudo cp -p /etc/resolv.conf miniroot/etc/
 
 if [ "$ARCHITECTURE" = "x86" ] || [ "$ARCHITECTURE" = "x86_64" ]; then
     echo "Architecture is x86 or x86_64, hence not using qemu-arm-static"
-    sudo chroot miniroot /bin/sh -ex build.sh
+    sudo cp build.sh miniroot/build.sh && sudo chroot miniroot /bin/sh -ex /build.sh
 else
     echo "Architecture is something else, hence using qemu-arm-static"
     sudo apt-get -y install qemu-user-static
     sudo cp $(which qemu-arm-static) miniroot/usr/bin
     # sudo chroot miniroot qemu-arm-static /bin/sh -ex <build.sh
-    sudo chroot miniroot qemu-arm-static /bin/sh -ex build.sh
+    sudo cp build.sh miniroot/build.sh && sudo chroot miniroot qemu-arm-static /bin/sh -ex /build.sh
 fi
 
 #############################################


### PR DESCRIPTION
This PR removes the need for [uraimo/run-on-arch-action](https://github.com/uraimo/run-on-arch-action).

Advantages:
* We can now pin all ingredients including Alpine Linux for all architectures
* Less complex
* Fewer external dependencies
* No more Docker needed
* All architectures now build in the same way
* Build speed did not suffer (this one surprised me)