### PR TITLE
Build patched libfuse3 to find more fusermount binaries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ cd fuse-3.*/
 patch -p1 < ../patches/libfuse/mount.c.diff
 mkdir build
 cd build
-meson setup --prefix=/usr/bin ..
+meson setup --prefix=/usr ..
 meson configure --default-library static
 ninja install
 cd ../../

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ cd fuse-3.*/
 patch -p1 < ../patches/libfuse/mount.c.diff
 mkdir build
 cd build
-meson setup ..
+meson setup --prefix=/usr/bin ..
 meson configure --default-library static
 ninja install
 cd ../../

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ if ! command -v apk; then
 fi
 
 apk update
-apk add alpine-sdk util-linux strace file autoconf automake libtool
+apk add alpine-sdk util-linux strace file autoconf automake libtool xz
 
 # Build static libfuse3 with patch for https://github.com/AppImage/type2-runtime/issues/10
 apk add eudev-dev gettext-dev linux-headers meson # From https://git.alpinelinux.org/aports/tree/main/fuse3/APKBUILD

--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,7 @@ wget "https://github.com/probonopd/libfuse/commit/bb5e23bb6d7ccb3a1f456fd35b716f
 patch -p1 < bb5e23bb6d7ccb3a1f456fd35b716f6c3a9557c4.diff
 mkdir build
 cd build
+meson setup ..
 meson configure --default-library static
 ninja install -v
 cd ../../

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ mkdir build
 cd build
 meson setup ..
 meson configure --default-library static
-ninja install -v
+ninja install
 cd ../../
 
 # Build static squashfuse

--- a/build.sh
+++ b/build.sh
@@ -15,8 +15,7 @@ apk add eudev-dev gettext-dev linux-headers meson # From https://git.alpinelinux
 wget -c -q "https://github.com/libfuse/libfuse/releases/download/fuse-3.15.0/fuse-3.15.0.tar.xz"
 tar xf fuse-3.*.tar.xz
 cd fuse-3.*/
-wget "https://github.com/probonopd/libfuse/commit/bb5e23bb6d7ccb3a1f456fd35b716f6c3a9557c4.diff" # FIXME: Store diff locally
-patch -p1 < bb5e23bb6d7ccb3a1f456fd35b716f6c3a9557c4.diff
+patch -p1 < ../patches/libfuse/mount.c.diff
 mkdir build
 cd build
 meson setup ..

--- a/build.sh
+++ b/build.sh
@@ -10,8 +10,21 @@ fi
 apk update
 apk add alpine-sdk util-linux strace file autoconf automake libtool
 
+# Build static libfuse3 with patch for https://github.com/AppImage/type2-runtime/issues/10
+apk add eudev-dev gettext-dev linux-headers meson # From https://git.alpinelinux.org/aports/tree/main/fuse3/APKBUILD
+wget -c -q "https://github.com/libfuse/libfuse/releases/download/fuse-3.15.0/fuse-3.15.0.tar.xz"
+tar xf fuse-3.*.tar.xz
+cd fuse-3.*/
+wget "https://github.com/probonopd/libfuse/commit/bb5e23bb6d7ccb3a1f456fd35b716f6c3a9557c4.diff" # FIXME: Store diff locally
+patch -p1 < bb5e23bb6d7ccb3a1f456fd35b716f6c3a9557c4.diff
+mkdir build
+cd build
+meson configure --default-library static
+ninja install -v
+cd ../../
+
 # Build static squashfuse
-apk add fuse3-dev fuse3-static zstd-dev zlib-dev zlib-static # fuse-static fuse-dev
+apk add zstd-dev zlib-dev zlib-static # fuse3-dev fuse3-static fuse-static fuse-dev
 find / -name "libzstd.*" 2>/dev/null || true
 wget -c -q "https://github.com/vasi/squashfuse/archive/e51978c.tar.gz"
 tar xf e51978c.tar.gz

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -18,6 +18,7 @@ cd -
 #############################################
 
 sudo cp -r ./src miniroot/src
+sudo cp -r ./patches miniroot/patches
 
 sudo mount -o bind /dev miniroot/dev
 sudo mount -t proc none miniroot/proc

--- a/patches/libfuse/mount.c.diff
+++ b/patches/libfuse/mount.c.diff
@@ -1,5 +1,5 @@
 diff --git a/lib/mount.c b/lib/mount.c
-index d71e6fc55..36071164f 100644
+index d71e6fc55..acc1711ff 100644
 --- a/lib/mount.c
 +++ b/lib/mount.c
 @@ -41,7 +41,6 @@
@@ -51,18 +51,18 @@ index d71e6fc55..36071164f 100644
 +			return prog;
 +	}
 +
-+	// Check if there is a binary "fusermount3" on the $PATH
++	// Check if there is a binary "fusermount3"
 +	prog = findBinaryInFusermountDir("fusermount3");
 +	if (access(prog, X_OK) == 0)
 +		return prog;
 +
-+	// Check if there is a binary called "fusermount" on the $PATH
++	// Check if there is a binary called "fusermount"
 +	// This is known to work for our purposes
 +	prog = findBinaryInFusermountDir("fusermount");
 +	if (access(prog, X_OK) == 0)
 +		return prog;
 +
-+	// For i = 4...99, check if there is a binary called "fusermount" + i on the $PATH
++	// For i = 4...99, check if there is a binary called "fusermount" + i
 +	// It is not yet known whether this will work for our purposes, but it is better than not even attempting
 +	for (int i = 4; i < 100; i++) {
 +		prog = findBinaryInFusermountDir("fusermount" + i);
@@ -128,4 +128,3 @@ index d71e6fc55..36071164f 100644
 +		perror("fuse: failed to exec fusermount");
  		_exit(1);
  	}
- 

--- a/patches/libfuse/mount.c.diff
+++ b/patches/libfuse/mount.c.diff
@@ -1,5 +1,5 @@
 diff --git a/lib/mount.c b/lib/mount.c
-index d71e6fc55..1c70c8c87 100644
+index d71e6fc55..36071164f 100644
 --- a/lib/mount.c
 +++ b/lib/mount.c
 @@ -41,7 +41,6 @@
@@ -10,12 +10,12 @@ index d71e6fc55..1c70c8c87 100644
  #define FUSE_COMMFD_ENV		"_FUSE_COMMFD"
  
  #ifndef HAVE_FORK
-@@ -117,17 +116,87 @@ static const struct fuse_opt fuse_mount_opts[] = {
+@@ -117,17 +116,79 @@ static const struct fuse_opt fuse_mount_opts[] = {
  	FUSE_OPT_END
  };
  
 +int fileExists(const char* path);
-+char* findBinaryOnPath(const char* binaryName);
++char* findBinaryInFusermountDir(const char* binaryName);
 +
 +int fileExists(const char* path) {
 +    FILE* file = fopen(path, "r");
@@ -26,54 +26,46 @@ index d71e6fc55..1c70c8c87 100644
 +    return 0;
 +}
 +
-+char* findBinaryOnPath(const char* binaryName) {
-+    const char* path = getenv("PATH");
-+    const char* delimiter = ":";
-+    char* pathCopy = strdup(path); // Create a copy of the PATH string
++char* findBinaryInFusermountDir(const char* binaryName) {
++    // For security reasons, we do not search the binary on the $PATH;
++	// instead, we check if the binary exists in FUSERMOUNT_DIR
++	// as defined in meson.build
++	char* binaryPath = malloc(strlen(FUSERMOUNT_DIR) + strlen(binaryName) + 2);
++	strcpy(binaryPath, FUSERMOUNT_DIR);
++	strcat(binaryPath, "/");
++	strcat(binaryPath, binaryName);
++	if (fileExists(binaryPath)) {
++		return binaryPath;
++	}
 +
-+    char* directory = strtok(pathCopy, delimiter);
-+    while (directory != NULL) {
-+        char fullPath[256];
-+        snprintf(fullPath, sizeof(fullPath), "%s/%s", directory, binaryName);
-+
-+        if (fileExists(fullPath)) {
-+            free(pathCopy); // Release the memory allocated by strdup
-+            return strdup(fullPath);
-+        }
-+
-+        directory = strtok(NULL, delimiter);
-+    }
-+
-+    free(pathCopy); // Release the memory allocated by strdup
-+    return NULL; // File not found on the $PATH
++	// If the binary does not exist in FUSERMOUNT_DIR, return NULL
++	return NULL;
 +}
 +
 +static const char *fuse_mount_prog(void)
 +{
 +	// Check if the FUSERMOUNT_PROG environment variable is set and if so, use it
 +	const char *prog = getenv("FUSERMOUNT_PROG");
-+	// Find the binary with the name specified in FUSERMOUNT_PROG on the $PATH
-+	prog = findBinaryOnPath(prog);
 +	if (prog) {
 +		if (access(prog, X_OK) == 0)
 +			return prog;
 +	}
 +
 +	// Check if there is a binary "fusermount3" on the $PATH
-+	prog = findBinaryOnPath("fusermount3");
++	prog = findBinaryInFusermountDir("fusermount3");
 +	if (access(prog, X_OK) == 0)
 +		return prog;
 +
 +	// Check if there is a binary called "fusermount" on the $PATH
 +	// This is known to work for our purposes
-+	prog = findBinaryOnPath("fusermount");
++	prog = findBinaryInFusermountDir("fusermount");
 +	if (access(prog, X_OK) == 0)
 +		return prog;
 +
 +	// For i = 4...99, check if there is a binary called "fusermount" + i on the $PATH
 +	// It is not yet known whether this will work for our purposes, but it is better than not even attempting
 +	for (int i = 4; i < 100; i++) {
-+		prog = findBinaryOnPath("fusermount" + i);
++		prog = findBinaryInFusermountDir("fusermount" + i);
 +		if (access(prog, X_OK) == 0)
 +			return prog;
 +	}
@@ -101,7 +93,7 @@ index d71e6fc55..1c70c8c87 100644
  		exec_fusermount(argv);
  		_exit(1);
  	} else if (pid != -1)
-@@ -300,7 +369,7 @@ void fuse_kern_unmount(const char *mountpoint, int fd)
+@@ -300,7 +361,7 @@ void fuse_kern_unmount(const char *mountpoint, int fd)
  		return;
  
  	if(pid == 0) {
@@ -110,7 +102,7 @@ index d71e6fc55..1c70c8c87 100644
  				       "--", mountpoint, NULL };
  
  		exec_fusermount(argv);
-@@ -346,7 +415,7 @@ static int setup_auto_unmount(const char *mountpoint, int quiet)
+@@ -346,7 +407,7 @@ static int setup_auto_unmount(const char *mountpoint, int quiet)
  			}
  		}
  
@@ -119,7 +111,7 @@ index d71e6fc55..1c70c8c87 100644
  		argv[a++] = "--auto-unmount";
  		argv[a++] = "--";
  		argv[a++] = mountpoint;
-@@ -407,7 +476,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
+@@ -407,7 +468,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
  			}
  		}
  
@@ -128,7 +120,7 @@ index d71e6fc55..1c70c8c87 100644
  		if (opts) {
  			argv[a++] = "-o";
  			argv[a++] = opts;
-@@ -421,7 +490,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
+@@ -421,7 +482,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
  		snprintf(env, sizeof(env), "%i", fds[0]);
  		setenv(FUSE_COMMFD_ENV, env, 1);
  		exec_fusermount(argv);

--- a/patches/libfuse/mount.c.diff
+++ b/patches/libfuse/mount.c.diff
@@ -1,0 +1,139 @@
+diff --git a/lib/mount.c b/lib/mount.c
+index d71e6fc55..1c70c8c87 100644
+--- a/lib/mount.c
++++ b/lib/mount.c
+@@ -41,7 +41,6 @@
+ #define umount2(mnt, flags) unmount(mnt, (flags == 2) ? MNT_FORCE : 0)
+ #endif
+ 
+-#define FUSERMOUNT_PROG		"fusermount3"
+ #define FUSE_COMMFD_ENV		"_FUSE_COMMFD"
+ 
+ #ifndef HAVE_FORK
+@@ -117,17 +116,87 @@ static const struct fuse_opt fuse_mount_opts[] = {
+ 	FUSE_OPT_END
+ };
+ 
++int fileExists(const char* path);
++char* findBinaryOnPath(const char* binaryName);
++
++int fileExists(const char* path) {
++    FILE* file = fopen(path, "r");
++    if (file) {
++        fclose(file);
++        return 1;
++    }
++    return 0;
++}
++
++char* findBinaryOnPath(const char* binaryName) {
++    const char* path = getenv("PATH");
++    const char* delimiter = ":";
++    char* pathCopy = strdup(path); // Create a copy of the PATH string
++
++    char* directory = strtok(pathCopy, delimiter);
++    while (directory != NULL) {
++        char fullPath[256];
++        snprintf(fullPath, sizeof(fullPath), "%s/%s", directory, binaryName);
++
++        if (fileExists(fullPath)) {
++            free(pathCopy); // Release the memory allocated by strdup
++            return strdup(fullPath);
++        }
++
++        directory = strtok(NULL, delimiter);
++    }
++
++    free(pathCopy); // Release the memory allocated by strdup
++    return NULL; // File not found on the $PATH
++}
++
++static const char *fuse_mount_prog(void)
++{
++	// Check if the FUSERMOUNT_PROG environment variable is set and if so, use it
++	const char *prog = getenv("FUSERMOUNT_PROG");
++	// Find the binary with the name specified in FUSERMOUNT_PROG on the $PATH
++	prog = findBinaryOnPath(prog);
++	if (prog) {
++		if (access(prog, X_OK) == 0)
++			return prog;
++	}
++
++	// Check if there is a binary "fusermount3" on the $PATH
++	prog = findBinaryOnPath("fusermount3");
++	if (access(prog, X_OK) == 0)
++		return prog;
++
++	// Check if there is a binary called "fusermount" on the $PATH
++	// This is known to work for our purposes
++	prog = findBinaryOnPath("fusermount");
++	if (access(prog, X_OK) == 0)
++		return prog;
++
++	// For i = 4...99, check if there is a binary called "fusermount" + i on the $PATH
++	// It is not yet known whether this will work for our purposes, but it is better than not even attempting
++	for (int i = 4; i < 100; i++) {
++		prog = findBinaryOnPath("fusermount" + i);
++		if (access(prog, X_OK) == 0)
++			return prog;
++	}
++
++	// If all else fails, return NULL
++	return NULL;
++}
++
+ static void exec_fusermount(const char *argv[])
+ {
+-	execv(FUSERMOUNT_DIR "/" FUSERMOUNT_PROG, (char **) argv);
+-	execvp(FUSERMOUNT_PROG, (char **) argv);
++	const char *fusermount_prog = fuse_mount_prog();
++	if (fusermount_prog) {
++		execv(fusermount_prog, (char **) argv);
++	}
+ }
+ 
+ void fuse_mount_version(void)
+ {
+ 	int pid = fork();
+ 	if (!pid) {
+-		const char *argv[] = { FUSERMOUNT_PROG, "--version", NULL };
++		const char *argv[] = { fuse_mount_prog(), "--version", NULL };
+ 		exec_fusermount(argv);
+ 		_exit(1);
+ 	} else if (pid != -1)
+@@ -300,7 +369,7 @@ void fuse_kern_unmount(const char *mountpoint, int fd)
+ 		return;
+ 
+ 	if(pid == 0) {
+-		const char *argv[] = { FUSERMOUNT_PROG, "-u", "-q", "-z",
++		const char *argv[] = { fuse_mount_prog(), "-u", "-q", "-z",
+ 				       "--", mountpoint, NULL };
+ 
+ 		exec_fusermount(argv);
+@@ -346,7 +415,7 @@ static int setup_auto_unmount(const char *mountpoint, int quiet)
+ 			}
+ 		}
+ 
+-		argv[a++] = FUSERMOUNT_PROG;
++		argv[a++] = fuse_mount_prog();
+ 		argv[a++] = "--auto-unmount";
+ 		argv[a++] = "--";
+ 		argv[a++] = mountpoint;
+@@ -407,7 +476,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
+ 			}
+ 		}
+ 
+-		argv[a++] = FUSERMOUNT_PROG;
++		argv[a++] = fuse_mount_prog();
+ 		if (opts) {
+ 			argv[a++] = "-o";
+ 			argv[a++] = opts;
+@@ -421,7 +490,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
+ 		snprintf(env, sizeof(env), "%i", fds[0]);
+ 		setenv(FUSE_COMMFD_ENV, env, 1);
+ 		exec_fusermount(argv);
+-		perror("fuse: failed to exec fusermount3");
++		perror("fuse: failed to exec fusermount");
+ 		_exit(1);
+ 	}
+ 


### PR DESCRIPTION
Build static libfuse3 with a patch to find `fusermount` in the following way:
1. Absolute path contained in the `FUSERMOUNT_PROG` environment variable
2. `fusermount3` on the `$PATH`
3. `fusermount` on the `$PATH` (known to work for our purposes)
4. `fusermount4...99` on the `$PATH`(speculative attempt at future-proofing; but better than not trying at all)

Closes https://github.com/AppImage/type2-runtime/issues/10