### PR TITLE
Upload to GitHub releases with pyuploadtool

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches:    
+    branches:
       - 'main'
   pull_request:
 
@@ -13,7 +13,7 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
 # The default Debian shell (dash) is faster than bash at running scripts,
 # and using bash when it is not needed doesn't make sense.
 defaults:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,9 +64,20 @@ jobs:
         name: artifacts
         path: ./out/*
 
-    - name: Upload to releases
-      if: github.event_name != 'pull_request' && github.ref_name == 'main'
-      uses: softprops/action-gh-release@v1
-      with:
-        files: out/*
-        tag_name: continuous
+  upload:
+    name: Create release and upload artifacts
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+      - name: Inspect directory after downloading artifacts
+        run: ls -alFR
+      - name: Create release and upload artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
+            chmod +x pyuploadtool-x86_64.AppImage
+            ./pyuploadtool-x86_64.AppImage --appimage-extract-and-run artifacts/*


### PR DESCRIPTION
[pyuploadtool](https://github.com/TheAssassin/pyuploadtool/) is the spiritual successor to uploadtool.sh. While adding a lot of error handling, it basically provides the same experience: create continuous releases on the main branch, create releases upon tags, otherwise skip the upload.