### PR TITLE
Fix buffer overflows when argv[0] or env variables are longer than PATH_MAX

### DIFF
--- a/src/runtime/runtime.c
+++ b/src/runtime/runtime.c
@@ -1344,10 +1344,18 @@ int main(int argc, char* argv[]) {
      */
     if (getenv("TARGET_APPIMAGE") == NULL) {
         strcpy(appimage_path, "/proc/self/exe");
-        strcpy(argv0_path, argv[0]);
+        char *res = memccpy(argv0_path, argv[0], '\0', sizeof(argv0_path));
+        if (res == NULL) {
+            fprintf(stderr, "Program name too big\n");
+            exit(EXIT_EXECERROR);
+        }
     } else {
-        strcpy(appimage_path, getenv("TARGET_APPIMAGE"));
-        strcpy(argv0_path, getenv("TARGET_APPIMAGE"));
+        char *res1 = memccpy(appimage_path, getenv("TARGET_APPIMAGE"), '\0', sizeof(appimage_path));
+        char *res2 = memccpy(argv0_path, getenv("TARGET_APPIMAGE"), '\0', sizeof(argv0_path));
+        if (res1 == NULL || res2 == NULL) {
+            fprintf(stderr, "TARGET_APPIMAGE environment variable too big\n");
+            exit(EXIT_EXECERROR);
+        }
     }
 
     // temporary directories are required in a few places
@@ -1356,8 +1364,13 @@ int main(int argc, char* argv[]) {
 
     {
         const char* const TMPDIR = getenv("TMPDIR");
-        if (TMPDIR != NULL)
-            strcpy(temp_base, getenv("TMPDIR"));
+        if (TMPDIR != NULL) {
+            char *res = memccpy(temp_base, TMPDIR, '\0', sizeof(temp_base));
+            if (res == NULL) {
+                fprintf(stderr, "TMPDIR environemnt variable too big\n");
+                exit(EXIT_EXECERROR);
+            }
+        }
     }
 
     fs_offset = appimage_get_elf_size(appimage_path);


### PR DESCRIPTION
When the runtime is invoked, it copies (strcpy) argv[0] or the TARGET_APPIMAGE environemnt variable into a buffer that has a dimension of PATH_MAX, and same thing with the TMPDIR env variable.
If the values saved in argv[0] or those environemnt variables are longer than PATH_MAX, the runtime currently segfaults due to buffer overflow.

This patch introduces a simple check that exits with an error message if that happens instead of causing a segfault. This is obtained by changing strcpy to [memccpy](https://www.man7.org/linux/man-pages/man3/memccpy.3p.html), a POSIX standard function that makes it easy to detect truncation (check the return value is NULL).