### PR TITLE
Trigger appimagetool build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,11 +122,21 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { Octokit } = require("@octokit/rest");
-            const octokit = new Octokit({ auth: context.github.token });          
-            const response = await octokit.rest.actions.createWorkflowDispatch({
-              owner: 'AppImage',
-              repo: 'appimagetool',
-              workflow_id: 'build.yml',
-              ref: 'main'
+            const response = await fetch('https://api.github.com/repos/AppImage/appimagetool/actions/workflows/build.yml/dispatches', {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${context.github.token}`,
+                'Accept': 'application/vnd.github.v3+json',
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({
+                ref: 'main'
+              })
             });
+      
+            if (!response.ok) {
+              const error = await response.json();
+              throw new Error(`Failed to trigger workflow: ${error.message}`);
+            } else {
+              console.log('Workflow triggered successfully');
+            }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,6 +65,19 @@ jobs:
         # copy pubkey so that it's included with the files uploaded to the release page
         cp signing-pubkey.asc out/
 
+    - name: Trigger appimagetool Build
+      uses: actions/github-script@v5
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const octokit = new Octokit({ auth: `${{ github.token }}` });
+          const response = await octokit.rest.actions.createWorkflowDispatch({
+            owner: 'AppImage',
+            repo: 'appimagetool',
+            workflow_id: 'build.yml',
+            ref: 'main'
+          });
+
     - uses: actions/upload-artifact@v3
       with:
         name: artifacts
@@ -116,3 +129,15 @@ jobs:
             wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
             chmod +x pyuploadtool-x86_64.AppImage
             ./pyuploadtool-x86_64.AppImage --appimage-extract-and-run artifacts/*
+      - name: Trigger appimagetool build
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const octokit = new Octokit({ auth: `${{ github.token }}` });
+            const response = await octokit.rest.actions.createWorkflowDispatch({
+              owner: 'AppImage',
+              repo: 'appimagetool',
+              workflow_id: 'build.yml',
+              ref: 'main'
+            });

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,19 +65,6 @@ jobs:
         # copy pubkey so that it's included with the files uploaded to the release page
         cp signing-pubkey.asc out/
 
-    - name: Trigger appimagetool Build
-      uses: actions/github-script@v5
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const octokit = new Octokit({ auth: `${{ github.token }}` });
-          const response = await octokit.rest.actions.createWorkflowDispatch({
-            owner: 'AppImage',
-            repo: 'appimagetool',
-            workflow_id: 'build.yml',
-            ref: 'main'
-          });
-
     - uses: actions/upload-artifact@v3
       with:
         name: artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,7 +122,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const octokit = new Octokit({ auth: `${{ github.token }}` });
+            const { Octokit } = require("@octokit/rest");
+            const octokit = new Octokit({ auth: context.github.token });          
             const response = await octokit.rest.actions.createWorkflowDispatch({
               owner: 'AppImage',
               repo: 'appimagetool',


### PR DESCRIPTION
Try to trigger an appimagetool build in addition to uploading the continuous build to GitHub Releases.

Thus, when a change in this repository prevents the appimagetool AppImage from being built correctly, we will know immediately rather than a few months down the line.

This in part might have prevented

* https://github.com/AppImage/appimagetool/issues/58

from having happened unnoticed.