### PR TITLE
Remove superfluous -type3 suffix from artifacts

### DIFF
--- a/chroot/build.sh
+++ b/chroot/build.sh
@@ -46,12 +46,12 @@ cd -
 GIT_COMMIT="$(cat src/runtime/version)"
 export GIT_COMMIT
 cd src/runtime
-make runtime-fuse3 -j"$(nproc)"
-file runtime-fuse3
-strip runtime-fuse3
-ls -lh runtime-fuse3
-echo -ne 'AI\x02' | dd of=runtime-fuse3 bs=1 count=3 seek=8 conv=notrunc # magic bytes, always do AFTER strip
+make runtime -j"$(nproc)"
+file runtime
+strip runtime
+ls -lh runtime
+echo -ne 'AI\x02' | dd of=runtime bs=1 count=3 seek=8 conv=notrunc # magic bytes, always do AFTER strip
 cd -
 
 mkdir -p out
-cp src/runtime/runtime-fuse3 "out/runtime-fuse3-${ARCHITECTURE}"
+cp src/runtime/runtime "out/runtime-${ARCHITECTURE}"

--- a/chroot/chroot_build.sh
+++ b/chroot/chroot_build.sh
@@ -85,4 +85,4 @@ esac
 
 cd "$repo_root_dir"
 mkdir -p ./out/
-sudo find "$tempdir"/miniroot/ -type f -executable -name 'runtime-fuse3' -exec cp {} "out/runtime-${appimage_arch}" \;
+sudo find "$tempdir"/miniroot/ -type f -executable -name 'runtime' -exec cp {} "out/runtime-${appimage_arch}" \;

--- a/scripts/build-in-container.sh
+++ b/scripts/build-in-container.sh
@@ -17,19 +17,19 @@ cp -R src "$build_dir"/
 pushd "$build_dir"
 
 pushd src/runtime/
-make -j"$(nproc)" runtime-fuse3
+make -j"$(nproc)" runtime
 
-file runtime-fuse3
+file runtime
 
 # optimize for size
 # TODO: should be part of the Makefile
-strip runtime-fuse3
+strip runtime
 
 # "classic" magic bytes which cannot be embedded with compiler magic, always do AFTER strip
 # TODO: should be part of the Makefile
-echo -ne 'AI\x02' | dd of=runtime-fuse3 bs=1 count=3 seek=8 conv=notrunc
+echo -ne 'AI\x02' | dd of=runtime bs=1 count=3 seek=8 conv=notrunc
 
-ls -lh runtime-fuse3
+ls -lh runtime
 
 # append architecture prefix
 # since uname gives the kernel architecture but we need the userland architecture, we check /bin/bash
@@ -49,8 +49,8 @@ else
     exit 2
 fi
 
-mv runtime-fuse3 runtime-fuse3-"$architecture"
-cp runtime-fuse3-"$architecture" "$out_dir"/
+mv runtime runtime-"$architecture"
+cp runtime-"$architecture" "$out_dir"/
 
 ls -al "$out_dir"
 

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -2,20 +2,20 @@ CC            = gcc
 CFLAGS        = -std=gnu99 -s -Os -D_FILE_OFFSET_BITS=64 -DGIT_COMMIT=\"${GIT_COMMIT}\" -T data_sections.ld -ffunction-sections -fdata-sections -Wl,--gc-sections -static -Wall -Werror
 LIBS          = -lsquashfuse -lsquashfuse_ll -lzstd -lz
 
-all: runtime-fuse3 runtime-fuse3
+all: runtime
 
 # Compile runtime
-runtime-fuse3.o: runtime.c
-	$(CC) -I/usr/local/include/squashfuse -I/usr/include/fuse -o runtime-fuse3.o -c $(CFLAGS) $^
+runtimey.o: runtime.c
+	$(CC) -I/usr/local/include/squashfuse -I/usr/include/fuse -o runtime.o -c $(CFLAGS) $^
 
-runtime-fuse3: runtime-fuse3.o
-	$(CC) $(CFLAGS) $^ $(LIBS) -lfuse -o runtime-fuse3
+runtime: runtime.o
+	$(CC) $(CFLAGS) $^ $(LIBS) -lfuse -o runtime
 
-runtime-fuse3.o: runtime.c
-	$(CC) -I/usr/local/include/squashfuse -I/usr/include/fuse3 -o runtime-fuse3.o -c $(CFLAGS) $^
+runtime.o: runtime.c
+	$(CC) -I/usr/local/include/squashfuse -I/usr/include/fuse3 -o runtime.o -c $(CFLAGS) $^
 
-runtime-fuse3: runtime-fuse3.o
-	$(CC) $(CFLAGS) $^ $(LIBS) -lfuse3 -o runtime-fuse3
+runtime: runtime.o
+	$(CC) $(CFLAGS) $^ $(LIBS) -lfuse3 -o runtime
 
 clean:
-	rm -f *.o runtime-fuse3 runtime-fuse3
+	rm -f *.o runtime


### PR DESCRIPTION
fuse2 is no longer supported. I also fixed a few oversights from its removal.

Fixes https://github.com/AppImage/appimagetool/issues/58.