### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Binaries are provided on GitHub Releases. Should you need to build the runtime l
 
 ```
 export ALPINE_ARCH=x86_64
-./chroot/chroot_build.sh # Or execute the steps in it manually
+./scripts/chroot/chroot_build.sh # Or execute the steps in it manually
 ```
 
 This whole process takes only a few seconds, e.g., on GitHub Codespaces.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,11 @@ __Please note:__ This repository is meant to be extremely simple.
 Binaries are provided on GitHub Releases. Should you need to build the runtime locally or on GitHub Codespaces, the following will build the contents of this repository in an Alpine container:
 
 ```
-export ARCHITECTURE=x86_64
-./chroot_build.sh # Or execute the steps in it manually
+export ALPINE_ARCH=x86_64
+./chroot/chroot_build.sh # Or execute the steps in it manually
 ```
 
 This whole process takes only a few seconds, e.g., on GitHub Codespaces.
-
 
 ## Signing
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ export ALPINE_ARCH=x86_64
 
 This whole process takes only a few seconds, e.g., on GitHub Codespaces.
 
+See [BUILD.md](BUILD.md) for more information, including on how to build using Docker.
+
 ## Signing
 
 Release builds are signed automatically using GnuPG. The corresponding public key can be found in the file `signing-pubkey.asc`.


### PR DESCRIPTION
Paths and variable names have been changed recently but the documentation has not been updated.

While we are at it, why not also document how to use Docker interactively, right above the line

> This whole process takes only a few seconds, e.g., on GitHub Codespaces.

```
If you would like to use Docker instead of chroot, the following will build the contents of this repository in an Alpine container:
...
````

What exactly to write there @TheAssassin?