### PR TITLE
Simplify Makefile

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -1,21 +1,11 @@
 CC            = gcc
 CFLAGS        = -std=gnu99 -Os -D_FILE_OFFSET_BITS=64 -DGIT_COMMIT=\"${GIT_COMMIT}\" -T data_sections.ld -ffunction-sections -fdata-sections -Wl,--gc-sections -static -Wall -Werror
-LIBS          = -lsquashfuse -lsquashfuse_ll -lzstd -lz
+LIBS          = -lsquashfuse -lsquashfuse_ll -lzstd -lz -lfuse3
 
 all: runtime
 
-# Compile runtime
-runtimey.o: runtime.c
-	$(CC) -I/usr/local/include/squashfuse -I/usr/include/fuse -o runtime.o -c $(CFLAGS) $^
-
-runtime: runtime.o
-	$(CC) $(CFLAGS) $^ $(LIBS) -lfuse -o runtime
-
-runtime.o: runtime.c
-	$(CC) -I/usr/local/include/squashfuse -I/usr/include/fuse3 -o runtime.o -c $(CFLAGS) $^
-
-runtime: runtime.o
-	$(CC) $(CFLAGS) $^ $(LIBS) -lfuse3 -o runtime
+runtime: runtime.c
+	$(CC) -I/usr/local/include/squashfuse -I/usr/include/fuse3 $(CFLAGS) $^ $(LIBS) -o $@
 
 clean:
-	rm -f *.o runtime
+	rm -f runtime


### PR DESCRIPTION
Remove redundant steps in an effort to further simplify things.
I also think there was a typo in there.

Every line of code we can remove is a line of code that can't have a bug and won't need maintenance.