### PR TITLE
Add GNU debug link to load debug symbols in gdb

### DIFF
--- a/scripts/build-in-container.sh
+++ b/scripts/build-in-container.sh
@@ -23,8 +23,7 @@ file runtime
 
 objcopy --only-keep-debug runtime runtime.debug
 
-# optimize for size
-strip runtime
+strip --strip-debug --strip-unneeded runtime
 
 # "classic" magic bytes which cannot be embedded with compiler magic, always do AFTER strip
 # TODO: should be part of the Makefile
@@ -51,9 +50,11 @@ else
 fi
 
 mv runtime runtime-"$architecture"
-cp runtime-"$architecture" "$out_dir"/
-
 mv runtime.debug runtime-"$architecture".debug
+
+objcopy --add-gnu-debuglink runtime-"$architecture".debug runtime-"$architecture"
+
+cp runtime-"$architecture" "$out_dir"/
 cp runtime-"$architecture".debug "$out_dir"/
 
 ls -al "$out_dir"


### PR DESCRIPTION
Along with the modifications to the strip call, this seems to fix the broken relationship between the two files. Also, one no longer needs to load the debug symbols manually.

Ideally, one can put the runtime.debug file in the same directory as the AppImage, then run gdb my.AppImage.

Changes inspired by https://invent.kde.org/packaging/craft/-/blob/7c627a015c72ea7da4177375729dfe21e1810755/bin/utils.py#L1305-1305.

Fixes #25.