### PR TITLE
Update all actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Get git hash
       run: |
@@ -65,7 +65,7 @@ jobs:
         # copy pubkey so that it's included with the files uploaded to the release page
         cp signing-pubkey.asc out/
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: artifacts
         path: out/*
@@ -85,7 +85,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Get git hash
       run: |
@@ -107,7 +107,7 @@ jobs:
       - build
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
       - name: Inspect directory after downloading artifacts
         run: ls -alFR
       - name: Create release and upload artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: artifacts
+        name: artifacts ${{ matrix.appimage_arch }}
         path: out/*
 
   build-in-chroot:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -116,4 +116,4 @@ jobs:
         run: |
             wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
             chmod +x pyuploadtool-x86_64.AppImage
-            ./pyuploadtool-x86_64.AppImage --appimage-extract-and-run artifacts/*
+            ./pyuploadtool-x86_64.AppImage --appimage-extract-and-run artifacts*/*


### PR DESCRIPTION
A potential security issue has been fixed in download-artifact. Its update also requires an update of the corresponding upload action. I thought it's a good idea to update the rest as well.