### PR TITLE
Find usermountN and set FUSERMOUNT_PROG if not set

### DIFF
--- a/patches/libfuse/mount.c.diff
+++ b/patches/libfuse/mount.c.diff
@@ -1,5 +1,5 @@
 diff --git a/lib/mount.c b/lib/mount.c
-index d71e6fc55..acc1711ff 100644
+index d71e6fc..ab3f54b 100644
 --- a/lib/mount.c
 +++ b/lib/mount.c
 @@ -41,7 +41,6 @@
@@ -10,78 +10,43 @@ index d71e6fc55..acc1711ff 100644
  #define FUSE_COMMFD_ENV		"_FUSE_COMMFD"
  
  #ifndef HAVE_FORK
-@@ -117,17 +116,79 @@ static const struct fuse_opt fuse_mount_opts[] = {
+@@ -117,17 +116,44 @@ static const struct fuse_opt fuse_mount_opts[] = {
  	FUSE_OPT_END
  };
  
-+int fileExists(const char* path);
-+char* findBinaryInFusermountDir(const char* binaryName);
-+
-+int fileExists(const char* path) {
-+    FILE* file = fopen(path, "r");
-+    if (file) {
-+        fclose(file);
-+        return 1;
-+    }
-+    return 0;
-+}
-+
-+char* findBinaryInFusermountDir(const char* binaryName) {
-+    // For security reasons, we do not search the binary on the $PATH;
-+	// instead, we check if the binary exists in FUSERMOUNT_DIR
-+	// as defined in meson.build
-+	char* binaryPath = malloc(strlen(FUSERMOUNT_DIR) + strlen(binaryName) + 2);
-+	strcpy(binaryPath, FUSERMOUNT_DIR);
-+	strcat(binaryPath, "/");
-+	strcat(binaryPath, binaryName);
-+	if (fileExists(binaryPath)) {
-+		return binaryPath;
-+	}
-+
-+	// If the binary does not exist in FUSERMOUNT_DIR, return NULL
-+	return NULL;
-+}
-+
-+static const char *fuse_mount_prog(void)
++/**
++ * Returns FUSERMOUNT_PROG path from environment variable.
++ *
++ * If $FUSERMOUNT_PROG is not set, the program exits.
++ * 
++ * Call with FUSERMOUNT_PROG_DEBUG=nonzerovalue to make the code print the value before evaluation.
++ */
++static const char *fusermountProg(void)
 +{
-+	// Check if the FUSERMOUNT_PROG environment variable is set and if so, use it
-+	const char *prog = getenv("FUSERMOUNT_PROG");
-+	if (prog) {
-+		if (access(prog, X_OK) == 0)
-+			return prog;
++	static const char envVar[] = "FUSERMOUNT_PROG";
++	char *fusermountProg = getenv(envVar);
++
++	static const char debugEnvVarSuffix[] = "_DEBUG";
++	char debugEnvVar[sizeof(envVar) + sizeof(debugEnvVarSuffix) + 1];
++	sprintf(debugEnvVar, "%s%s", envVar, debugEnvVarSuffix);
++
++	if (fusermountProg == NULL) {
++		fprintf(stderr, "Error: $%s not set\n", envVar);
++		exit(1);
 +	}
 +
-+	// Check if there is a binary "fusermount3"
-+	prog = findBinaryInFusermountDir("fusermount3");
-+	if (access(prog, X_OK) == 0)
-+		return prog;
-+
-+	// Check if there is a binary called "fusermount"
-+	// This is known to work for our purposes
-+	prog = findBinaryInFusermountDir("fusermount");
-+	if (access(prog, X_OK) == 0)
-+		return prog;
-+
-+	// For i = 4...99, check if there is a binary called "fusermount" + i
-+	// It is not yet known whether this will work for our purposes, but it is better than not even attempting
-+	for (int i = 4; i < 100; i++) {
-+		prog = findBinaryInFusermountDir("fusermount" + i);
-+		if (access(prog, X_OK) == 0)
-+			return prog;
++	if (getenv(debugEnvVar) != NULL) {
++		fprintf(stderr, "$%s: %s\n", envVar, fusermountProg);
 +	}
 +
-+	// If all else fails, return NULL
-+	return NULL;
++	return fusermountProg;
 +}
 +
  static void exec_fusermount(const char *argv[])
  {
 -	execv(FUSERMOUNT_DIR "/" FUSERMOUNT_PROG, (char **) argv);
 -	execvp(FUSERMOUNT_PROG, (char **) argv);
-+	const char *fusermount_prog = fuse_mount_prog();
-+	if (fusermount_prog) {
-+		execv(fusermount_prog, (char **) argv);
-+	}
++	execv(fusermountProg(), (char **) argv);
  }
  
  void fuse_mount_version(void)
@@ -89,42 +54,52 @@ index d71e6fc55..acc1711ff 100644
  	int pid = fork();
  	if (!pid) {
 -		const char *argv[] = { FUSERMOUNT_PROG, "--version", NULL };
-+		const char *argv[] = { fuse_mount_prog(), "--version", NULL };
++		const char *argv[] = { fusermountProg(), "--version", NULL };
  		exec_fusermount(argv);
  		_exit(1);
  	} else if (pid != -1)
-@@ -300,7 +361,7 @@ void fuse_kern_unmount(const char *mountpoint, int fd)
+@@ -300,7 +326,7 @@ void fuse_kern_unmount(const char *mountpoint, int fd)
  		return;
  
  	if(pid == 0) {
 -		const char *argv[] = { FUSERMOUNT_PROG, "-u", "-q", "-z",
-+		const char *argv[] = { fuse_mount_prog(), "-u", "-q", "-z",
++		const char *argv[] = { fusermountProg(), "-u", "-q", "-z",
  				       "--", mountpoint, NULL };
  
  		exec_fusermount(argv);
-@@ -346,7 +407,7 @@ static int setup_auto_unmount(const char *mountpoint, int quiet)
+@@ -346,7 +372,7 @@ static int setup_auto_unmount(const char *mountpoint, int quiet)
  			}
  		}
  
 -		argv[a++] = FUSERMOUNT_PROG;
-+		argv[a++] = fuse_mount_prog();
++		argv[a++] = fusermountProg();
  		argv[a++] = "--auto-unmount";
  		argv[a++] = "--";
  		argv[a++] = mountpoint;
-@@ -407,7 +468,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
- 			}
- 		}
- 
--		argv[a++] = FUSERMOUNT_PROG;
-+		argv[a++] = fuse_mount_prog();
- 		if (opts) {
- 			argv[a++] = "-o";
- 			argv[a++] = opts;
-@@ -421,7 +482,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
+@@ -357,7 +383,7 @@ static int setup_auto_unmount(const char *mountpoint, int quiet)
  		snprintf(env, sizeof(env), "%i", fds[0]);
  		setenv(FUSE_COMMFD_ENV, env, 1);
  		exec_fusermount(argv);
 -		perror("fuse: failed to exec fusermount3");
-+		perror("fuse: failed to exec fusermount");
++		perror("fuse: failed to exec $FUSERMOUNT_PROG");
  		_exit(1);
  	}
+ 
+@@ -407,7 +433,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
+ 			}
+ 		}
+ 
+-		argv[a++] = FUSERMOUNT_PROG;
++		argv[a++] = fusermountProg();
+ 		if (opts) {
+ 			argv[a++] = "-o";
+ 			argv[a++] = opts;
+@@ -421,7 +447,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
+ 		snprintf(env, sizeof(env), "%i", fds[0]);
+ 		setenv(FUSE_COMMFD_ENV, env, 1);
+ 		exec_fusermount(argv);
+-		perror("fuse: failed to exec fusermount3");
++		perror("fuse: failed to exec $FUSERMOUNT_PROG");
+ 		_exit(1);
+ 	}
+ 

--- a/src/runtime/runtime.c
+++ b/src/runtime/runtime.c
@@ -1427,6 +1427,11 @@ char* appimage_hexlify(const char* bytes, const size_t numBytes) {
 }
 
 int main(int argc, char* argv[]) {
+    const bool verbose = (getenv("VERBOSE") != NULL);
+    if (verbose) {
+        fprintf(stderr, "Running in verbose mode\n");
+    }
+
     char appimage_path[PATH_MAX];
     char argv0_path[PATH_MAX];
     char* arg;
@@ -1491,8 +1496,6 @@ int main(int argc, char* argv[]) {
         printf("%zu\n", fs_offset);
         exit(0);
     }
-
-    const bool verbose = (getenv("VERBOSE") != NULL);
 
     /* extract the AppImage */
     if (arg && strcmp(arg, "appimage-extract") == 0) {


### PR DESCRIPTION
This approach avoids tricky patching of upstream code and exports `FUSERMOUNT_PROG` instead.

Closes #15, #16, #31, #32, #35, #36, #37