### PR TITLE
Make binaries position independent

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -1,5 +1,5 @@
 CC            = gcc
-CFLAGS        = -std=gnu99 -Os -D_FILE_OFFSET_BITS=64 -DGIT_COMMIT=\"${GIT_COMMIT}\" -T data_sections.ld -ffunction-sections -fdata-sections -Wl,--gc-sections -static -Wall -Werror
+CFLAGS        = -std=gnu99 -Os -D_FILE_OFFSET_BITS=64 -DGIT_COMMIT=\"${GIT_COMMIT}\" -T data_sections.ld -ffunction-sections -fdata-sections -Wl,--gc-sections -static -Wall -Werror -fPIE
 LIBS          = -lsquashfuse -lsquashfuse_ll -lzstd -lz -lfuse3
 
 all: runtime


### PR DESCRIPTION
Should be standard nowadays. It allows the kernel to enable some security-related features like ASLR.