### PR TITLE
Update squashfuse to latest release

### DIFF
--- a/scripts/common/install-dependencies.sh
+++ b/scripts/common/install-dependencies.sh
@@ -33,9 +33,9 @@ popd
 # Minimize binary size
 export CFLAGS="-ffunction-sections -fdata-sections -Os"
 
-wget "https://github.com/vasi/squashfuse/archive/e51978c.tar.gz"
-echo "f544029ad30d8fbde4e4540c574b8cdc6d38b94df025a98d8551a9441f07d341  e51978c.tar.gz" | sha256sum -c -
-tar xf e51978c.tar.gz
+wget "https://github.com/vasi/squashfuse/archive/0.5.2.tar.gz"
+echo "db0238c5981dabbd80ee09ae15387f390091668ca060a7bc38047912491443d3  0.5.2.tar.gz" | sha256sum -c -
+tar xf 0.5.2.tar.gz
 pushd squashfuse-*/
 ./autogen.sh
 ./configure CFLAGS="${CFLAGS} -no-pie" LDFLAGS=-static

--- a/src/runtime/runtime.c
+++ b/src/runtime/runtime.c
@@ -1032,7 +1032,7 @@ int fusefs_main(int argc, char* argv[], void (* mounted)(void)) {
     opts.offset = 0;
     opts.idle_timeout_secs = 0;
     if (fuse_opt_parse(&args, &opts, fuse_opts, sqfs_opt_proc) == -1)
-        sqfs_usage(argv[0], true);
+        sqfs_usage(argv[0], true, true);
 
 #if FUSE_USE_VERSION >= 30
     if (fuse_parse_cmdline(&args, &fuse_cmdline_opts) != 0)
@@ -1042,9 +1042,9 @@ int fusefs_main(int argc, char* argv[], void (* mounted)(void)) {
                                &fuse_cmdline_opts.mt,
                                &fuse_cmdline_opts.foreground) == -1)
 #endif
-        sqfs_usage(argv[0], true);
+        sqfs_usage(argv[0], true, true);
     if (fuse_cmdline_opts.mountpoint == NULL)
-        sqfs_usage(argv[0], true);
+        sqfs_usage(argv[0], true, true);
 
     /* fuse_daemonize() will unconditionally clobber fds 0-2.
      *


### PR DESCRIPTION
We used a pinned commit that enabled Zstd support but we can just use the latest release as well. The minor code modification is needed because the function's signature has changed upstream.