### PR TITLE
Revert "Build static PIE binaries with clang"

### DIFF
--- a/scripts/chroot/build.sh
+++ b/scripts/chroot/build.sh
@@ -12,7 +12,7 @@ find /scripts
 apk update
 apk add alpine-sdk util-linux strace file autoconf automake libtool xz bash \
     eudev-dev gettext-dev linux-headers meson \
-    zstd-dev zlib-dev zlib-static clang
+    zstd-dev zlib-dev zlib-static # fuse3-dev fuse3-static fuse-static fuse-dev
 
 /scripts/common/install-dependencies.sh
 /scripts/build-runtime.sh

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -5,7 +5,7 @@ FROM ${docker_arch}/alpine:latest
 RUN apk add --no-cache \
     bash alpine-sdk util-linux strace file autoconf automake libtool xz \
     eudev-dev gettext-dev linux-headers meson \
-    zstd-dev zstd-static zlib-dev zlib-static clang
+    zstd-dev zstd-static zlib-dev zlib-static # fuse3-dev fuse3-static fuse-static fuse-dev
 
 COPY scripts/common/install-dependencies.sh /tmp/scripts/common/install-dependencies.sh
 COPY patches/ /tmp/patches/

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -1,5 +1,5 @@
-CC            = clang
-CFLAGS        = -std=gnu99 -Os -D_FILE_OFFSET_BITS=64 -DGIT_COMMIT=\"${GIT_COMMIT}\" -T data_sections.ld -ffunction-sections -fdata-sections -Wl,--gc-sections -static -Wall -Werror -static-pie
+CC            = gcc
+CFLAGS        = -std=gnu99 -Os -D_FILE_OFFSET_BITS=64 -DGIT_COMMIT=\"${GIT_COMMIT}\" -T data_sections.ld -ffunction-sections -fdata-sections -Wl,--gc-sections -static -Wall -Werror -fPIE
 LIBS          = -lsquashfuse -lsquashfuse_ll -lzstd -lz -lfuse3
 
 all: runtime


### PR DESCRIPTION
Reverts AppImage/type2-runtime#88
due to https://github.com/AppImage/type2-runtime/issues/96

A new PR can be made in case it can be done in a way that does not cause #96.