### PR TITLE
Use Dependabot to update Dockerfile and actions pipelines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/scripts/docker/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This should create automated PRs to update the pinned release in our Dockerfile, allowing us to make sure everything works before merging updates and roll them back easily if needed, as well as keep our GitHub actions pipelines up to date.

Closes #79