### PR TITLE
Re-add PIE build flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ squashfs-root/
 
 # debug environments
 .vagrant/
+
+# build products
+src/runtime/runtime

--- a/scripts/chroot/build.sh
+++ b/scripts/chroot/build.sh
@@ -12,7 +12,7 @@ find /scripts
 apk update
 apk add alpine-sdk util-linux strace file autoconf automake libtool xz bash \
     eudev-dev gettext-dev linux-headers meson \
-    zstd-dev zlib-dev zlib-static # fuse3-dev fuse3-static fuse-static fuse-dev
+    zstd-dev zlib-dev zlib-static clang
 
 /scripts/common/install-dependencies.sh
 /scripts/build-runtime.sh

--- a/scripts/common/install-dependencies.sh
+++ b/scripts/common/install-dependencies.sh
@@ -38,7 +38,7 @@ echo "db0238c5981dabbd80ee09ae15387f390091668ca060a7bc38047912491443d3  0.5.2.ta
 tar xf 0.5.2.tar.gz
 pushd squashfuse-*/
 ./autogen.sh
-./configure CFLAGS="${CFLAGS} -no-pie" LDFLAGS=-static
+./configure LDFLAGS="-static"
 make -j"$(nproc)"
 make install
 /usr/bin/install -c -m 644 ./*.h '/usr/local/include/squashfuse'

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.20
 RUN apk add --no-cache \
     bash alpine-sdk util-linux strace file autoconf automake libtool xz \
     eudev-dev gettext-dev linux-headers meson \
-    zstd-dev zstd-static zlib-dev zlib-static # fuse3-dev fuse3-static fuse-static fuse-dev
+    zstd-dev zstd-static zlib-dev zlib-static clang
 
 COPY scripts/common/install-dependencies.sh /tmp/scripts/common/install-dependencies.sh
 COPY patches/ /tmp/patches/

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -1,6 +1,6 @@
 GIT_COMMIT := $(shell cat version)
-CC            = gcc
-CFLAGS        = -std=gnu99 -Os -D_FILE_OFFSET_BITS=64 -DGIT_COMMIT=\"$(GIT_COMMIT)\" -T data_sections.ld -ffunction-sections -fdata-sections -Wl,--gc-sections -static -Wall -Werror
+CC            = clang
+CFLAGS        = -std=gnu99 -Os -D_FILE_OFFSET_BITS=64 -DGIT_COMMIT=\"$(GIT_COMMIT)\" -T data_sections.ld -ffunction-sections -fdata-sections -Wl,--gc-sections -static -Wall -Werror -static-pie
 LIBS          = -lsquashfuse -lsquashfuse_ll -lzstd -lz -lfuse3
 
 all: runtime


### PR DESCRIPTION
It is not proven that it was the fact the binary was linked as PIE that caused https://github.com/AppImage/type2-runtime/issues/96 in edge cases. Therefore, re-adding it. @probonopd wants to test this more thoroughly now, but in theory, this can be merged.