### PR TITLE
[WIP] Add support for LoongArch64

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -15,13 +15,14 @@ The chroot-based environment is designed for people who really do not want to us
 To run a build, use the following command:
 
 ```sh
-> env ALPINE_ARCH=<arch>  chroot/chroot_build.sh
+> env ALPINE_ARCH=<arch>  scripts/chroot/chroot_build.sh
 
 # example calls:
-> env ALPINE_ARCH=x86_64  chroot/chroot_build.sh
-> env ALPINE_ARCH=i686    chroot/chroot_build.sh
-> env ALPINE_ARCH=armhf   chroot/chroot_build.sh
-> env ALPINE_ARCH=aarch64 chroot/chroot_build.sh
+> env ALPINE_ARCH=x86_64      scripts/chroot/chroot_build.sh
+> env ALPINE_ARCH=i686        scripts/chroot/chroot_build.sh
+> env ALPINE_ARCH=armhf       scripts/chroot/chroot_build.sh
+> env ALPINE_ARCH=aarch64     scripts/chroot/chroot_build.sh
+> env ALPINE_ARCH=loongarch64 scripts/chroot/chroot_build.sh
 ```
 
 The script will download an Alpine miniroot image, extract it into a specific location, bind-mount a set of temporary filesystems (e.g., `/proc`) there, chroot into there and run the build script. It attempts to unmount the previously mounted paths again.

--- a/scripts/build-runtime.sh
+++ b/scripts/build-runtime.sh
@@ -42,6 +42,8 @@ elif [[ "$runtime" =~ EABI5 ]]; then
     architecture=armhf
 elif [[ "$runtime" =~ x86-64 ]]; then
     architecture=x86_64
+elif [[ "$runtime" =~ "64-bit .*, LoongArch" ]]; then
+    architecture=loongarch64
 else
     echo "Unsupported architecture: ${runtime#* }"
     exit 2

--- a/scripts/chroot/chroot_build.sh
+++ b/scripts/chroot/chroot_build.sh
@@ -4,7 +4,7 @@ set -ex
 
 if [ -z "${ALPINE_ARCH}" ]; then
     echo "Usage: env ALPINE_ARCH=<arch> $0"
-    echo "Example values: x86_64 x86 armhf aarch64"
+    echo "Example values: x86_64 x86 armhf aarch64 loongarch64"
     exit 2
 fi
 
@@ -35,7 +35,14 @@ cd "$tempdir"
 # Download and extract minimal Alpine system
 #############################################
 
-wget "http://dl-cdn.alpinelinux.org/alpine/v3.17/releases/${ALPINE_ARCH}/alpine-minirootfs-3.17.2-${ALPINE_ARCH}.tar.gz"
+if [ "${ALPINE_ARCH}" = loongarch64 ]; then
+    alpine_version=3.21.0  # first version with support
+else
+    alpine_version=3.17.2
+fi
+
+alpine_major_minor="${alpine_version%.*}"
+wget "http://dl-cdn.alpinelinux.org/alpine/v${alpine_major_minor}/releases/${ALPINE_ARCH}/alpine-minirootfs-${alpine_version}-${ALPINE_ARCH}.tar.gz"
 mkdir -p ./miniroot
 cd ./miniroot
 sudo tar xf ../alpine-minirootfs-*-"${ALPINE_ARCH}".tar.gz
@@ -72,6 +79,11 @@ elif [ "$ALPINE_ARCH" = "armhf" ] ; then
     echo "Architecture is armhf, hence using qemu-arm-static"
     sudo cp "$(which qemu-arm-static)" miniroot/usr/bin
     sudo cp "$repo_root_dir"/scripts/chroot/build.sh miniroot/build.sh && sudo chroot miniroot qemu-arm-static /bin/sh -ex /scripts/chroot/build.sh
+elif [ "$ALPINE_ARCH" = "loongarch64" ] ; then
+    echo "Architecture is loongarch64, hence using qemu-loongarch64-static"
+    sudo cp "$(which qemu-loongarch64-static)" miniroot/usr/bin
+    sudo cp "$repo_root_dir"/scripts/chroot/build.sh miniroot/build.sh && sudo chroot miniroot qemu-loongarch64-static /bin/sh -ex /scripts/chroot/build.sh
+
 else
     echo "Edit chroot_build.sh to support this architecture as well, it should be easy"
     exit 1


### PR DESCRIPTION
Fixes #108.

I only have a tiny bit of free time today but fortunately the project contains almost no platform-specific details, so why not finish this before heading over to `$DAY_JOB`...

Note: This is now marked WIP because Alpine Linux didn't support LoongArch64 until 3.21, but Alpine 3.21's `zstd-dev` no longer includes the static library, so the final link failed. Have to workaround this but it should be the last obstacle before full LoongArch support; hence I'm posting this now for reviews.