### PR TITLE
Suggest to bump alpine release to latest known today: 3.21.0.

### DIFF
--- a/scripts/chroot/build.sh
+++ b/scripts/chroot/build.sh
@@ -12,7 +12,7 @@ find /scripts
 apk update
 apk add alpine-sdk util-linux strace file autoconf automake libtool xz bash \
     eudev-dev gettext-dev linux-headers meson \
-    zstd-dev zlib-dev zlib-static clang
+    zstd-dev zstd-static zlib-dev zlib-static clang
 
 /scripts/common/install-dependencies.sh
 /scripts/build-runtime.sh

--- a/scripts/chroot/chroot_build.sh
+++ b/scripts/chroot/chroot_build.sh
@@ -35,7 +35,11 @@ cd "$tempdir"
 # Download and extract minimal Alpine system
 #############################################
 
-wget "http://dl-cdn.alpinelinux.org/alpine/v3.17/releases/${ALPINE_ARCH}/alpine-minirootfs-3.17.2-${ALPINE_ARCH}.tar.gz"
+ALPINE_RELEASE="3.21.0"
+wget "http://dl-cdn.alpinelinux.org/alpine/v${ALPINE_RELEASE%.*}/releases/${ALPINE_ARCH}/alpine-minirootfs-${ALPINE_RELEASE}-${ALPINE_ARCH}.tar.gz"
+wget "http://dl-cdn.alpinelinux.org/alpine/v${ALPINE_RELEASE%.*}/releases/${ALPINE_ARCH}/alpine-minirootfs-${ALPINE_RELEASE}-${ALPINE_ARCH}.tar.gz.sha256"
+sha256sum -c alpine-minirootfs-${ALPINE_RELEASE}-${ALPINE_ARCH}.tar.gz.sha256
+
 mkdir -p ./miniroot
 cd ./miniroot
 sudo tar xf ../alpine-minirootfs-*-"${ALPINE_ARCH}".tar.gz


### PR DESCRIPTION
Hello all,
I am not namely a developer (more a sysadmin) but very interested to understand how AppImage works in details.
As I am trying to rebuild on my own this 'runtime', that Alpine base can be upgraded to take benefit of improvement (perf, security, ...).
For the moment, I am only able to test this build with the proposed Vagrantfile virtualbox VM (release 7.0.22) with chroot method and seems to complete with success (eventhought I don't know yet how to actually test it in an AppImage :()
Tia for kind attention, take care,
Rudy.