### PR TITLE
Suggest to bump fuse release to latest known today: 3.16.2 (including new signify download validation).

### DIFF
--- a/scripts/chroot/build.sh
+++ b/scripts/chroot/build.sh
@@ -11,7 +11,7 @@ find /scripts
 
 apk update
 apk add alpine-sdk util-linux strace file autoconf automake libtool xz bash \
-    eudev-dev gettext-dev linux-headers meson \
+    eudev-dev gettext-dev linux-headers meson signify \
     zstd-dev zstd-static zlib-dev zlib-static clang
 
 /scripts/common/install-dependencies.sh

--- a/scripts/common/fuse-3.16.pub
+++ b/scripts/common/fuse-3.16.pub
@@ -1,0 +1,2 @@
+untrusted comment: signify public key
+RWQtnc3WSoYwHGAdfvtTTVX8RsAXrNwMb8xqVwlY8lYY2Fxn2QUDiPYK

--- a/scripts/common/install-dependencies.sh
+++ b/scripts/common/install-dependencies.sh
@@ -16,11 +16,17 @@ trap cleanup EXIT
 # needed to determine the path of the patches
 this_dir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
 
+FUSE_RELEASE="3.16.2"
+cp ${this_dir}/fuse-${FUSE_RELEASE%.*}.pub ${tmpdir}
+
 cd "$tmpdir"
 
-wget https://github.com/libfuse/libfuse/releases/download/fuse-3.15.0/fuse-3.15.0.tar.xz
-echo "70589cfd5e1cff7ccd6ac91c86c01be340b227285c5e200baa284e401eea2ca0  fuse-3.15.0.tar.xz" | sha256sum -c -
-tar xf fuse-3.*.tar.xz
+wget https://github.com/libfuse/libfuse/releases/download/fuse-${FUSE_RELEASE}/fuse-${FUSE_RELEASE}.tar.gz
+wget https://github.com/libfuse/libfuse/releases/download/fuse-${FUSE_RELEASE}/fuse-${FUSE_RELEASE}.tar.gz.sig
+#echo "70589cfd5e1cff7ccd6ac91c86c01be340b227285c5e200baa284e401eea2ca0  fuse-3.15.0.tar.xz" | sha256sum -c -
+signify -V -m fuse-${FUSE_RELEASE}.tar.gz -p fuse-${FUSE_RELEASE%.*}.pub
+
+tar xf fuse-3.*.tar.gz
 pushd fuse-3*/
 patch -p1 < "$this_dir"/../../patches/libfuse/mount.c.diff
 mkdir build

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -3,10 +3,11 @@ FROM alpine:3.21
 # includes dependencies from https://git.alpinelinux.org/aports/tree/main/fuse3/APKBUILD
 RUN apk add --no-cache \
     bash alpine-sdk util-linux strace file autoconf automake libtool xz \
-    eudev-dev gettext-dev linux-headers meson \
+    eudev-dev gettext-dev linux-headers meson signify \
     zstd-dev zstd-static zlib-dev zlib-static clang
 
-COPY scripts/common/install-dependencies.sh /tmp/scripts/common/install-dependencies.sh
+COPY scripts/common/install-dependencies.sh /tmp/scripts/common/.
+COPY scripts/common/fuse-3.*.pub /tmp/scripts/common/.
 COPY patches/ /tmp/patches/
 
 WORKDIR /tmp


### PR DESCRIPTION
Hello all,
Here am I back with the update of latest fuse lib I find on github.
My problem is that they now use 'signify' to validate their new src files and this required to download a key file: fuse-3.16.pub. 
For this first attempt:
- I just put it aside in scripts/common (may be to put else where?)
- I just download it with my web browser and include it the src tree: it may be exists another method to include a file from another project?
- Or simpler verify a local download to compute a sha256 sum and keep current validation?

This time I was able to build x86_64 runtime with 2 method  (chroot & docker).
Thx in advance for further advises,
Rudy.
