### PR TITLE
Update project URL in print_help

### DIFF
--- a/src/runtime/runtime.c
+++ b/src/runtime/runtime.c
@@ -696,7 +696,7 @@ void print_help(const char* appimage_path) {
             "License:\n"
             "  This executable contains code from\n"
             "  * runtime, licensed under the terms of\n"
-            "    https://github.com/probonopd/static-tools/blob/master/LICENSE\n"
+            "    https://github.com/AppImage/type2-runtime/blob/main/LICENSE\n"
             "  * musl libc, licensed under the terms of\n"
             "    https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT\n"
             "  * libfuse, licensed under the terms of\n"
@@ -707,7 +707,7 @@ void print_help(const char* appimage_path) {
             "    https://github.com/facebook/zstd/blob/dev/LICENSE\n"
             "  * zlib, licensed under the terms of\n"
             "    https://zlib.net/zlib_license.html\n"
-            "Please see https://github.com/probonopd/static-tools/\n"
+            "Please see https://github.com/AppImage/type2-runtime\n"
             "for information on how to obtain and build the source code\n", appimage_path);
 }
 


### PR DESCRIPTION
`--appimage-help` currently lists the URLs of
https://github.com/probonopd/static-tools/
which appears to be the repo where this code here originated from (09b0b437dfdf607cecf9b59303272770af5ad25c being the last common commit ID of the main/master branches).

AppImage users should be pointed towards the correct repo URL though if they are looking for the runtime source code, as mentioned in the help text. If there's an issue with the updated license help text, then this should obviously be changed, so please let me know with a diff.